### PR TITLE
Fix: fix autoincrement entity id strategy

### DIFF
--- a/src/main/java/com/ajou/travely/domain/Branch.java
+++ b/src/main/java/com/ajou/travely/domain/Branch.java
@@ -11,7 +11,7 @@ import javax.persistence.*;
 @NoArgsConstructor
 public class Branch {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "branch_id")
     private Long id;
 

--- a/src/main/java/com/ajou/travely/domain/Comment.java
+++ b/src/main/java/com/ajou/travely/domain/Comment.java
@@ -11,7 +11,7 @@ import javax.persistence.*;
 @Getter
 public class Comment {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "comment_id")
     private Long id;
 

--- a/src/main/java/com/ajou/travely/domain/Cost.java
+++ b/src/main/java/com/ajou/travely/domain/Cost.java
@@ -5,7 +5,7 @@ import javax.persistence.*;
 @Entity
 public class Cost {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name="cost_id")
     private Long id;
 

--- a/src/main/java/com/ajou/travely/domain/Payment.java
+++ b/src/main/java/com/ajou/travely/domain/Payment.java
@@ -5,7 +5,7 @@ import javax.persistence.*;
 @Entity
 public class Payment {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "payment_id")
     private Long id;
 

--- a/src/main/java/com/ajou/travely/domain/Photo.java
+++ b/src/main/java/com/ajou/travely/domain/Photo.java
@@ -10,7 +10,7 @@ import javax.persistence.*;
 @NoArgsConstructor
 public class Photo {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "photo_id")
     private Long id;
 

--- a/src/main/java/com/ajou/travely/domain/Place.java
+++ b/src/main/java/com/ajou/travely/domain/Place.java
@@ -3,12 +3,13 @@ package com.ajou.travely.domain;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
 @Entity
 public class Place {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "place_id")
     private Long id;
 

--- a/src/main/java/com/ajou/travely/domain/Post.java
+++ b/src/main/java/com/ajou/travely/domain/Post.java
@@ -11,7 +11,7 @@ import javax.persistence.*;
 @NoArgsConstructor
 public class Post {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "post_id")
     private Long id;
 

--- a/src/main/java/com/ajou/travely/domain/Reservation.java
+++ b/src/main/java/com/ajou/travely/domain/Reservation.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 @Entity
 public class Reservation {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "reservation_id")
     private Long id;
 

--- a/src/main/java/com/ajou/travely/domain/Schedule.java
+++ b/src/main/java/com/ajou/travely/domain/Schedule.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 @Entity
 public class Schedule {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "schedule_id")
     private Long id;
 

--- a/src/main/java/com/ajou/travely/domain/UserCost.java
+++ b/src/main/java/com/ajou/travely/domain/UserCost.java
@@ -11,7 +11,7 @@ import javax.persistence.*;
 @Getter
 public class UserCost {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_cost_id")
     private Long id;
 

--- a/src/main/java/com/ajou/travely/domain/UserTravel.java
+++ b/src/main/java/com/ajou/travely/domain/UserTravel.java
@@ -11,7 +11,7 @@ import javax.persistence.*;
 @Getter
 public class UserTravel {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name="user_travel_id")
     private Long id;
 

--- a/src/main/java/com/ajou/travely/repository/JpaTravelRepository.java
+++ b/src/main/java/com/ajou/travely/repository/JpaTravelRepository.java
@@ -1,7 +1,0 @@
-package com.ajou.travely.repository;
-
-import com.ajou.travely.domain.Travel;
-import org.springframework.stereotype.Repository;
-
-import javax.persistence.EntityManager;
-import java.util.Optional;


### PR DESCRIPTION
### 🔨 작업 내용
- id autogeneration strategy 추가
### 📐 구현한 내용
- `@GeneratedValue(strategy = GenerationType.IDENTITY)` 다음과 같이 strategy를 지정하지 않을 경우 각 테이블의 id 생성 규칙에 따라 id를 생성하기 때문에 strategy를 지정하여 모든 테이블이 동일한 id 생성 규칙을 갖도록 수정
### 🚧 논의 사항
- 
