### PR TITLE
feature/oauth_login_block_redirect_to_signup_with_no_email

### DIFF
--- a/src/main/java/com/ajou/travely/service/AuthService.java
+++ b/src/main/java/com/ajou/travely/service/AuthService.java
@@ -16,8 +16,7 @@ public class AuthService {
     public JSONObject kakaoAuthentication(String code) {
         AuthorizationKakao authorizationKakao = oauth2Service.callTokenApi(code);
         JSONObject userInfoFromKakao = oauth2Service.callGetUserByAccessToken(authorizationKakao.getAccess_token());
-        Long kakaoId = (Long) userInfoFromKakao.get("id");
-        JSONObject result = oauth2Service.setSessionOrRedirectToSignUp(kakaoId);
+        JSONObject result = oauth2Service.setSessionOrRedirectToSignUp(userInfoFromKakao);
         return result;
     }
 

--- a/src/main/java/com/ajou/travely/service/Oauth2Service.java
+++ b/src/main/java/com/ajou/travely/service/Oauth2Service.java
@@ -78,11 +78,7 @@ public class Oauth2Service {
             ResponseEntity<String> response = restTemplate.postForEntity(url, request, String.class);
             SecurityContext context = SecurityContextHolder.getContext();
             JSONObject userInfo = stringToJson(response.getBody());
-//            System.out.println("userInfo.get(\"id\") = " + userInfo.get("id"));
-//            JSONObject properties = (JSONObject) userInfo.get("properties");
-//            System.out.println("properties.get(\"nickname\") = " + properties.get("nickname"));
-//            Long kakaoId = (Long) userInfo.get("id");
-//            context.setAuthentication(new CustomAuthentication(kakaoId));
+
             return userInfo;
         }catch (RestClientException | ParseException ex) {
             ex.printStackTrace();
@@ -90,19 +86,26 @@ public class Oauth2Service {
         }
     }
 
-    public JSONObject setSessionOrRedirectToSignUp(Long kakaoId) {
+    public JSONObject setSessionOrRedirectToSignUp(JSONObject userInfoFromKakao) {
+        Long kakaoId = (Long) userInfoFromKakao.get("id");
+        JSONObject kakao_account = (JSONObject) userInfoFromKakao.get("kakao_account");
         Optional<User> user = userRepository.findByKakaoId(kakaoId);
         JSONObject result = new JSONObject();
-        if(user.isEmpty()) {
-            result.put("status", 301);
-            result.put("kakaoId", kakaoId);
-            return result;
+        if(kakao_account.get("email") != null) {
+            if(user.isEmpty()) {
+                result.put("status", 301);
+                result.put("kakaoId", kakaoId);
+                return result;
+            } else {
+                SecurityContext context = SecurityContextHolder.getContext();
+                User exUser = user.get();
+                context.setAuthentication(new CustomAuthentication(exUser));
+                result.put("status", 200);
+            }
         } else {
-            SecurityContext context = SecurityContextHolder.getContext();
-            User exUser = user.get();
-            context.setAuthentication(new CustomAuthentication(exUser));
-            result.put("status", 200);
+            result.put("status", 401);
         }
+
         return result;
     }
     public JSONObject stringToJson(String userInfo) throws ParseException {

--- a/src/test/java/com/ajou/travely/service/AuthServiceTest.java
+++ b/src/test/java/com/ajou/travely/service/AuthServiceTest.java
@@ -36,7 +36,12 @@ class AuthServiceTest {
     @DisplayName("Security Context에서 사용자 id 가져오기")
     @Rollback
     void getUserId() {
-        Long kakaoId = 123456789L;
+        JSONObject userInfoFromKakao = new JSONObject();
+        JSONObject kakao_account = new JSONObject();
+        kakao_account.put("email", "test@test.com");
+        userInfoFromKakao.put("id", 123456789L);
+        userInfoFromKakao.put("kakao_account", kakao_account);
+        Long kakaoId = (Long) userInfoFromKakao.get("id");
         User user = User.builder()
                 .type(Type.USER)
                 .email("test@email.com")
@@ -46,7 +51,7 @@ class AuthServiceTest {
                 .build();
 
         userRepository.save(user);
-        JSONObject result = oauth2Service.setSessionOrRedirectToSignUp(kakaoId);
+        JSONObject result = oauth2Service.setSessionOrRedirectToSignUp(userInfoFromKakao);
         Long userId = authService.getUserId();
 
         assertThat(result.get("status")).isEqualTo(200);

--- a/src/test/java/com/ajou/travely/service/CostServiceTest.java
+++ b/src/test/java/com/ajou/travely/service/CostServiceTest.java
@@ -9,7 +9,6 @@ import com.ajou.travely.repository.CostRepository;
 import com.ajou.travely.repository.TravelRepository;
 import com.ajou.travely.repository.UserCostRepository;
 import com.ajou.travely.repository.UserRepository;
-import javax.transaction.Transactional;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.*;

--- a/src/test/java/com/ajou/travely/service/Oauth2ServiceTest.java
+++ b/src/test/java/com/ajou/travely/service/Oauth2ServiceTest.java
@@ -40,7 +40,23 @@ class Oauth2ServiceTest {
     @DisplayName("카카오 유저 아이디를 통해 유저를 찾고 회원가입 여부 반환")
     @Rollback
     void testWhetherUserExists() {
-        Long kakaoId = 123456789L;
+        JSONObject userInfoFromKakao = new JSONObject();
+        JSONObject kakao_account = new JSONObject();
+        kakao_account.put("email", "test@test.com");
+        userInfoFromKakao.put("id", 123456789L);
+        userInfoFromKakao.put("kakao_account", kakao_account);
+        Long kakaoId = (Long) userInfoFromKakao.get("id");
+
+        JSONObject notSignedUpUserInfo = new JSONObject();
+        notSignedUpUserInfo.put("id", 123L);
+        notSignedUpUserInfo.put("kakao_account", kakao_account);
+
+        JSONObject userInfoWithoutEmail = new JSONObject();
+        JSONObject kakao_accountWithoutEmail = new JSONObject();
+        userInfoWithoutEmail.put("id", 1234L);
+        userInfoWithoutEmail.put("kakao_account", kakao_accountWithoutEmail);
+
+
         User user = User.builder()
                 .type(Type.USER)
                 .email("test@email.com")
@@ -51,9 +67,10 @@ class Oauth2ServiceTest {
 
         userRepository.save(user);
 
-        JSONObject s1 = oauth2Service.setSessionOrRedirectToSignUp(kakaoId);
+        JSONObject s1 = oauth2Service.setSessionOrRedirectToSignUp(userInfoFromKakao);
         User kakaoIdInAuthenticationDetail = (User) SecurityContextHolder.getContext().getAuthentication().getDetails();
-        JSONObject s2 = oauth2Service.setSessionOrRedirectToSignUp(123L);
+        JSONObject s2 = oauth2Service.setSessionOrRedirectToSignUp(notSignedUpUserInfo);
+        JSONObject s3 = oauth2Service.setSessionOrRedirectToSignUp(userInfoWithoutEmail);
 
         System.out.println("SecurityContextHolder.getContext().getAuthentication().getDetails() = " + SecurityContextHolder.getContext().getAuthentication().getDetails());
         SecurityContextHolder.getContext().getAuthentication().getAuthorities().stream().forEach(grantedAuthority -> {
@@ -61,6 +78,7 @@ class Oauth2ServiceTest {
         });
         assertThat(s1.get("status")).isEqualTo(200);
         assertThat(s2.get("status")).isEqualTo(301);
+        assertThat(s3.get("status")).isEqualTo(401);
         assertThat(kakaoIdInAuthenticationDetail.getKakaoId()).isEqualTo(kakaoId);
     }
 }


### PR DESCRIPTION
### 🔨 작업 내용
- 최초 카카오 로그인 시 이메일 선택 동의를 하지 않으면 회원가입으로 리다이렉트 되지 않도록 처리.
### 📐 구현한 내용
- feature : 카카오 이메일이 오지 않으면 회원가입 되지 않도록 status를 return
- test : 로직 수정에 따른 테스트 수정.
### 🚧 논의 사항
- 
