### PR TITLE
refactor/login-failure-handling

### DIFF
--- a/src/main/java/com/ajou/travely/controller/auth/AuthController.java
+++ b/src/main/java/com/ajou/travely/controller/auth/AuthController.java
@@ -2,6 +2,10 @@ package com.ajou.travely.controller.auth;
 
 import com.ajou.travely.controller.auth.dto.EmailPasswordInputDto;
 import com.ajou.travely.service.AuthService;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Example;
+import io.swagger.annotations.ExampleProperty;
 import lombok.RequiredArgsConstructor;
 import org.json.simple.JSONObject;
 import org.springframework.http.HttpHeaders;
@@ -23,8 +27,31 @@ public class AuthController {
     }
 
     @PostMapping("/v1/login")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "로그인 성공", examples = @Example(
+                    @ExampleProperty(value = "{\n" +
+                            "\t\"token\": \"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ7XCJ1c2VySWRcIjoxfSIsImlhdCI6MTY1MzU2MDQwNSwiZXhwIjoxNjU0MTY1MjA1fQ.HGC-6YVPo0jeK7W8HLulKP9_srsECJD1giODgihNmxg\"\n" +
+                            "}")
+            )),
+            @ApiResponse(code = 400, message = "잘못된 이메일", examples = @Example(
+                    @ExampleProperty(value = "{\n" +
+                            "\t\"status\": 400,\n" +
+                            "\t\"message\": \"USER RECORD IS NOT FOUND\",\n" +
+                            "\t\"exceptionMessage\": \"해당 이메일을 가진 사용자를 찾을 수 없습니다\"\n" +
+                            "}")
+            )),
+            @ApiResponse(code = 401, message = "잘못된 비밀번호", examples = @Example(
+                    @ExampleProperty(value = "{\n" +
+                            "\t\"status\": 401,\n" +
+                            "\t\"message\": \"INVALID PASSWORD\",\n" +
+                            "\t\"exceptionMessage\": \"잘못된 비밀번호 입니다.\"\n" +
+                            "}")
+            ))
+    })
     public ResponseEntity<JSONObject> login(@Valid @RequestBody EmailPasswordInputDto emailPasswordInputDto) {
-        JSONObject result = authService.login(emailPasswordInputDto);
+        String token = authService.login(emailPasswordInputDto);
+        JSONObject result = new JSONObject();
+        result.put("token", token);
         return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/ajou/travely/controller/auth/AuthController.java
+++ b/src/main/java/com/ajou/travely/controller/auth/AuthController.java
@@ -1,6 +1,7 @@
 package com.ajou.travely.controller.auth;
 
 import com.ajou.travely.controller.auth.dto.EmailPasswordInputDto;
+import com.ajou.travely.controller.auth.dto.LoginSuccessResponseDto;
 import com.ajou.travely.service.AuthService;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
@@ -48,10 +49,8 @@ public class AuthController {
                             "}")
             ))
     })
-    public ResponseEntity<JSONObject> login(@Valid @RequestBody EmailPasswordInputDto emailPasswordInputDto) {
-        String token = authService.login(emailPasswordInputDto);
-        JSONObject result = new JSONObject();
-        result.put("token", token);
-        return ResponseEntity.ok(result);
+    public ResponseEntity<LoginSuccessResponseDto> login(@Valid @RequestBody EmailPasswordInputDto emailPasswordInputDto) {
+        LoginSuccessResponseDto responseDto = authService.login(emailPasswordInputDto);
+        return ResponseEntity.ok(responseDto);
     }
 }

--- a/src/main/java/com/ajou/travely/controller/auth/dto/LoginSuccessResponseDto.java
+++ b/src/main/java/com/ajou/travely/controller/auth/dto/LoginSuccessResponseDto.java
@@ -1,0 +1,12 @@
+package com.ajou.travely.controller.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LoginSuccessResponseDto {
+    private String token;
+
+    public LoginSuccessResponseDto(String token) {
+        this.token = token;
+    }
+}

--- a/src/main/java/com/ajou/travely/service/AuthService.java
+++ b/src/main/java/com/ajou/travely/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.ajou.travely.service;
 
 import com.ajou.travely.controller.auth.dto.EmailPasswordInputDto;
+import com.ajou.travely.controller.auth.dto.LoginSuccessResponseDto;
 import com.ajou.travely.domain.AuthorizationKakao;
 import com.ajou.travely.domain.user.User;
 import com.ajou.travely.exception.ErrorCode;
@@ -35,7 +36,7 @@ public class AuthService {
         return user.getId();
     }
 
-    public String login(EmailPasswordInputDto emailPasswordInputDto) {
+    public LoginSuccessResponseDto login(EmailPasswordInputDto emailPasswordInputDto) {
         User user = userRepository.findByEmail(emailPasswordInputDto.getEmail())
                 .orElseThrow(() -> new RecordNotFoundException(
                         "해당 이메일을 가진 사용자를 찾을 수 없습니다",
@@ -48,7 +49,6 @@ public class AuthService {
             );
         }
         String token = jwtTokenProvider.createToken(user.getId());
-
-        return token;
+        return new LoginSuccessResponseDto(token);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ auth:
   kakaoOauth2ClinetId: 7e2da5ad6fb5d14c02874cc0880ae024
   frontendRedirectUrl: http://localhost:3000/
   jwtSecretKey: "test"
-  tokenValidTime: 10800000
+  tokenValidTime: 604800000
 
 spring:
   datasource:

--- a/src/test/java/com/ajou/travely/service/AuthServiceTest.java
+++ b/src/test/java/com/ajou/travely/service/AuthServiceTest.java
@@ -1,6 +1,7 @@
 package com.ajou.travely.service;
 
 import com.ajou.travely.controller.auth.dto.EmailPasswordInputDto;
+import com.ajou.travely.controller.auth.dto.LoginSuccessResponseDto;
 import com.ajou.travely.domain.user.CustomUserDetails;
 import com.ajou.travely.domain.user.UserType;
 import com.ajou.travely.domain.user.User;
@@ -82,7 +83,8 @@ class AuthServiceTest {
                 .password(password)
                 .build());
 
-        String token = authService.login(new EmailPasswordInputDto(email, password));
+        LoginSuccessResponseDto responseDto = authService.login(new EmailPasswordInputDto(email, password));
+        String token = responseDto.getToken();
         UsernamePasswordAuthenticationToken authentication = (UsernamePasswordAuthenticationToken) jwtTokenProvider.getAuthentication(token);
         CustomUserDetails principal = (CustomUserDetails) authentication.getPrincipal();
 


### PR DESCRIPTION
### 🔨 작업 내용
- 로그인 결과 반환하는 방식 수정.
- 스웨거에 로그인 결과 예시 작성.
- 토큰 유효 시간 연장.
### 📐 구현한 내용
- 로그인 결과 반환하는 방식 수정.
  - 기존 : JSON 객체를 직접 만들어서 status와 message 혹은 token을 넣어줌.
  - 개선 : 이메일 혹은 비밀번호가 일치하지 않을 경우 서비스에서 예외를 던져 처리, 로그인 성공 시 token 값이 JSONObject로 반환. 
- 스웨거에 로그인 결과 예시 작성.
- 토큰 유효 시간 연장.
### 🚧 논의 사항
- 
