### PR TITLE
Refactor/travel schedule order

### DIFF
--- a/src/main/java/com/ajou/travely/controller/travel/TravelController.java
+++ b/src/main/java/com/ajou/travely/controller/travel/TravelController.java
@@ -114,7 +114,7 @@ public class TravelController {
     }
 
     @GetMapping("/{travelId}/schedules/{scheduleId}")
-    public ResponseEntity<ScheduleResponseDto> getScheduleById(@PathVariable Long travelId,
+    public ResponseEntity<ScheduleResponseDto> showSchedule(@PathVariable Long travelId,
                                                                @PathVariable Long scheduleId) {
         return ResponseEntity.ok(scheduleService.getScheduleById(scheduleId));
     }

--- a/src/main/java/com/ajou/travely/controller/travel/dto/TravelResponseDto.java
+++ b/src/main/java/com/ajou/travely/controller/travel/dto/TravelResponseDto.java
@@ -3,16 +3,14 @@ package com.ajou.travely.controller.travel.dto;
 import com.ajou.travely.controller.schedule.dto.SimpleScheduleResponseDto;
 import com.ajou.travely.controller.user.dto.SimpleUserInfoDto;
 import com.ajou.travely.domain.Schedule;
+import com.ajou.travely.domain.UserTravel;
 import com.ajou.travely.domain.travel.Travel;
 import com.ajou.travely.domain.travel.TravelType;
+import lombok.Getter;
+
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import com.ajou.travely.domain.UserTravel;
-import lombok.Getter;
 
 @Getter
 public class TravelResponseDto {
@@ -45,14 +43,6 @@ public class TravelResponseDto {
                 .stream()
                 .map(SimpleScheduleResponseDto::new)
                 .collect(Collectors.toList());
-        if (entity.getScheduleOrder().isEmpty()) {
-            this.scheduleOrder = new ArrayList<>();
-        } else {
-            this.scheduleOrder = Arrays
-                    .stream(entity.getScheduleOrder().split(","))
-                    .map(Long::valueOf)
-                    .collect(Collectors.toList());
-        }
-
+        this.scheduleOrder = entity.getScheduleOrder();
     }
 }

--- a/src/main/java/com/ajou/travely/controller/travel/dto/TravelResponseDto.java
+++ b/src/main/java/com/ajou/travely/controller/travel/dto/TravelResponseDto.java
@@ -23,7 +23,6 @@ public class TravelResponseDto {
     private final TravelType travelType;
     private final List<SimpleUserInfoDto> users;
     private final List<SimpleScheduleResponseDto> schedules;
-    private final List<Long> scheduleOrder;
 
     public TravelResponseDto(Travel entity, List<Schedule> schedules) {
         this.id = entity.getId();
@@ -43,6 +42,5 @@ public class TravelResponseDto {
                 .stream()
                 .map(SimpleScheduleResponseDto::new)
                 .collect(Collectors.toList());
-        this.scheduleOrder = entity.getScheduleOrder();
     }
 }

--- a/src/main/java/com/ajou/travely/converter/ScheduleOrderConverter.java
+++ b/src/main/java/com/ajou/travely/converter/ScheduleOrderConverter.java
@@ -1,0 +1,33 @@
+package com.ajou.travely.converter;
+
+import javax.persistence.AttributeConverter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class ScheduleOrderConverter implements AttributeConverter<List<Long>, String> {
+    @Override
+    public String convertToDatabaseColumn(List<Long> attribute) {
+        if (Objects.isNull(attribute)) {
+            return "";
+        }
+        return attribute
+                .stream()
+                .map(String::valueOf)
+                .collect(Collectors.joining(","));
+    }
+
+    @Override
+    public List<Long> convertToEntityAttribute(String dbData) {
+        if (Objects.isNull(dbData) || dbData.isBlank()) {
+            return new ArrayList();
+        } else {
+            return Arrays
+                    .stream(dbData.split(","))
+                    .map(Long::valueOf)
+                    .collect(Collectors.toList());
+        }
+    }
+}

--- a/src/main/java/com/ajou/travely/domain/travel/Travel.java
+++ b/src/main/java/com/ajou/travely/domain/travel/Travel.java
@@ -1,8 +1,12 @@
 package com.ajou.travely.domain.travel;
 
 import com.ajou.travely.controller.travel.dto.TravelUpdateRequestDto;
+import com.ajou.travely.converter.ScheduleOrderConverter;
 import com.ajou.travely.domain.UserTravel;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -10,7 +14,6 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor
@@ -30,7 +33,8 @@ public class Travel {
 
     private LocalDate endDate;
 
-    private String scheduleOrder;
+    @Convert(converter = ScheduleOrderConverter.class)
+    private List<Long> scheduleOrder = new ArrayList<>();
 
     @Column(columnDefinition = "TEXT")
     private String memo;
@@ -64,12 +68,10 @@ public class Travel {
 
     public void setScheduleOrder(List<Long> scheduleOrder) {
         if (Objects.isNull(scheduleOrder)) {
-            scheduleOrder = new ArrayList<>();
+            this.scheduleOrder = new ArrayList<>();
+        } else {
+            this.scheduleOrder = scheduleOrder;
         }
-        this.scheduleOrder = scheduleOrder
-                .stream()
-                .map(String::valueOf)
-                .collect(Collectors.joining(","));
     }
 
     @PrePersist

--- a/src/main/java/com/ajou/travely/service/TravelService.java
+++ b/src/main/java/com/ajou/travely/service/TravelService.java
@@ -161,8 +161,12 @@ public class TravelService {
     @Transactional
     public TravelResponseDto getTravelById(Long travelId) {
         Travel travel = checkTravelRecord(travelId);
-        List<Schedule> schedules = travelRepository
-            .findSchedulesWithPlaceByTravelId(travel.getId());
+        Map<Long, Schedule> map = new HashMap<>();
+        travelRepository
+                .findSchedulesWithPlaceByTravelId(travelId)
+                .forEach(schedule -> map.put(schedule.getId(), schedule));
+        List<Schedule> schedules = new ArrayList<>();
+        travel.getScheduleOrder().forEach(id -> schedules.add(map.get(id)));
         return new TravelResponseDto(travel, schedules);
     }
 

--- a/src/main/java/com/ajou/travely/service/TravelService.java
+++ b/src/main/java/com/ajou/travely/service/TravelService.java
@@ -208,8 +208,13 @@ public class TravelService {
     @Transactional(readOnly = true)
     public List<SimpleScheduleResponseDto> getSchedulesByTravelId(Long travelId) {
         Travel travel = checkTravelRecord(travelId);
-        return travelRepository
-            .findSchedulesWithPlaceByTravelId(travelId)
+        Map<Long, Schedule> map = new HashMap<>();
+        travelRepository
+                .findSchedulesWithPlaceByTravelId(travelId)
+                .forEach(schedule -> map.put(schedule.getId(), schedule));
+        List<Schedule> schedules = new ArrayList<>();
+        travel.getScheduleOrder().forEach(id -> schedules.add(map.get(id)));
+        return schedules
             .stream()
             .map(SimpleScheduleResponseDto::new)
             .collect(Collectors.toList());

--- a/src/main/java/com/ajou/travely/service/TravelService.java
+++ b/src/main/java/com/ajou/travely/service/TravelService.java
@@ -199,7 +199,6 @@ public class TravelService {
     @Transactional(readOnly = true)
     public List<SimpleCostResponseDto> getCostsByTravelId(Long travelId) {
         List<Cost> costs = costRepository.findCostsByTravelId(travelId);
-
         return costs
             .stream()
             .map(SimpleCostResponseDto::new)
@@ -208,6 +207,7 @@ public class TravelService {
 
     @Transactional(readOnly = true)
     public List<SimpleScheduleResponseDto> getSchedulesByTravelId(Long travelId) {
+        Travel travel = checkTravelRecord(travelId);
         return travelRepository
             .findSchedulesWithPlaceByTravelId(travelId)
             .stream()

--- a/src/main/java/com/ajou/travely/service/TravelService.java
+++ b/src/main/java/com/ajou/travely/service/TravelService.java
@@ -161,12 +161,7 @@ public class TravelService {
     @Transactional
     public TravelResponseDto getTravelById(Long travelId) {
         Travel travel = checkTravelRecord(travelId);
-        Map<Long, Schedule> map = new HashMap<>();
-        travelRepository
-                .findSchedulesWithPlaceByTravelId(travelId)
-                .forEach(schedule -> map.put(schedule.getId(), schedule));
-        List<Schedule> schedules = new ArrayList<>();
-        travel.getScheduleOrder().forEach(id -> schedules.add(map.get(id)));
+        List<Schedule> schedules = sortSchedule(travel);
         return new TravelResponseDto(travel, schedules);
     }
 
@@ -212,13 +207,7 @@ public class TravelService {
     @Transactional(readOnly = true)
     public List<SimpleScheduleResponseDto> getSchedulesByTravelId(Long travelId) {
         Travel travel = checkTravelRecord(travelId);
-        Map<Long, Schedule> map = new HashMap<>();
-        travelRepository
-                .findSchedulesWithPlaceByTravelId(travelId)
-                .forEach(schedule -> map.put(schedule.getId(), schedule));
-        List<Schedule> schedules = new ArrayList<>();
-        travel.getScheduleOrder().forEach(id -> schedules.add(map.get(id)));
-        return schedules
+        return sortSchedule(travel)
             .stream()
             .map(SimpleScheduleResponseDto::new)
             .collect(Collectors.toList());
@@ -245,6 +234,16 @@ public class TravelService {
         User user = checkUserRecord(userId);
         Invitation invitation = checkInvitationRecord(code, user.getEmail());
         invitationRepository.delete(invitation);
+    }
+
+    private List<Schedule> sortSchedule(Travel travel) {
+        Map<Long, Schedule> map = new HashMap<>();
+        travelRepository
+                .findSchedulesWithPlaceByTravelId(travel.getId())
+                .forEach(schedule -> map.put(schedule.getId(), schedule));
+        List<Schedule> schedules = new ArrayList<>();
+        travel.getScheduleOrder().forEach(id -> schedules.add(map.get(id)));
+        return schedules;
     }
 
     private Travel checkTravelRecord(Long travelId) {


### PR DESCRIPTION
### 🔨 작업 내용
- travel의 schedule list 반환 시 schedule order에 맞춰 반환하도록 로직 수정
### 📐 구현한 내용
- converter를 이용해 travel entity가 schduleOrder를 List<Long> 타입으로 가질 수 있게 됐습니다.
- travel 단건 조회 시 정렬된 schedule을 반환하도록 수정했습니다.
- travel의 schdule 리스트 조회 시 정렬된 schedule을 반환하도록 수정했습니다.
### 🚧 논의 사항
-  travel 단건 조회 시 schedule list를 반환할 필요가 있는가?
  - 만약 그렇다면 travel의 schdule list 조회 api가 따로 존재할 필요가 있는가?
